### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.9-slim
+
+LABEL org.opencontainers.image.authors="vero.valeros@gmail.com,eldraco@gmail.com"
+
+ENV DESTINATION_DIR /netflowlabeler
+
+COPY . ${DESTINATION_DIR}/
+
+WORKDIR ${DESTINATION_DIR}
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Netflowlabeler
 [![Docker Image CI](https://github.com/stratosphereips/netflowlabeler/actions/workflows/docker-image.yml/badge.svg)](https://github.com/stratosphereips/netflowlabeler/actions/workflows/docker-image.yml)
+![GitHub last commit (branch)](https://img.shields.io/github/last-commit/stratosphereips/netflowlabeler/main)
+![Docker Pulls](https://img.shields.io/docker/pulls/stratosphereips/netflowlabeler?color=green)
+
 
 Author: Sebastian Garcia, eldraco@gmail.com, sebastian.garcia@agents.fel.cvut.cz
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Netflowlabeler
+[![Docker Image CI](https://github.com/stratosphereips/netflowlabeler/actions/workflows/docker-image.yml/badge.svg)](https://github.com/stratosphereips/netflowlabeler/actions/workflows/docker-image.yml)
+
 Author: Sebastian Garcia, eldraco@gmail.com, sebastian.garcia@agents.fel.cvut.cz
 
 Netflowlabeler is a Python tool to add labels to netflow text files. If you have a netflow text file and you want to add labels to it, you can add the labels and conditions to a configuration file and use this tool to assign them.
@@ -50,3 +52,7 @@ These are the possible fields that you can use in a configuration file to create
 - Packets
 - Bytes
 - Flows
+
+# Docker Image
+
+Netflow labeler has a public docker image with the latest version. 


### PR DESCRIPTION
Adding files to provide netflowlabeler with a docker image:
- Dockerfile: uses python:3.9-slim
- Code is copied to /netflowlabeler
- Run as usual
- There are no installations right now as the tool does not have any requirements.