### PR TITLE
Naming and small bug-fixes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: >-
-  Netflow Labeler: A configurable rule-based labeling tool for network flow files
+  NetflowLabeler: A configurable rule-based labeling tool for network flow files
 message: 'If you use this software, please cite it as below.'
 type: software
 authors:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ As a general rule, base your contribution on the `develop` branch.
 
 ## Persistent Git Branches
 
-The following git branches permanent in the Slips repository:
+The following git branches permanent in the repository:
 
 - `main`: contains the stable version of the repository.
 - `develop`: all new features should be based on this branch.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Netflowlabeler
+# NetflowLabeler
 [![Docker Image CI](https://github.com/stratosphereips/netflowlabeler/actions/workflows/docker-image.yml/badge.svg)](https://github.com/stratosphereips/netflowlabeler/actions/workflows/docker-image.yml)
 ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/stratosphereips/netflowlabeler/main)
 ![Docker Pulls](https://img.shields.io/docker/pulls/stratosphereips/netflowlabeler?color=green)
@@ -6,7 +6,7 @@
 
 Author: Sebastian Garcia, eldraco@gmail.com, sebastian.garcia@agents.fel.cvut.cz and Veronica Valeros valerver@fel.cvut.cz.
 
-Netflowlabeler is a Python tool to add labels to netflow text files. If you have a netflow text file and you want to add labels to it, you can add the labels and conditions to a configuration file and use this tool to assign them.
+NetflowLabeler is a Python tool to add labels to netflow text files. If you have a netflow text file and you want to add labels to it, you can add the labels and conditions to a configuration file and use this tool to assign them.
 
 The labels are assigned by following our own label ontology. The ontology is designed as configuration file that you can modify. You can add a generic labels and a detailed labels.
 


### PR DESCRIPTION
- Update tool name to be capitalized: NetflowLabeler instead of Netflowlabeler
- Remove old references to Slips on the Contributing guidelines
- Update Citation to match tool name