### PR TITLE
Bugfix parse dhcp log header

### DIFF
--- a/zeek-files-labeler.py
+++ b/zeek-files-labeler.py
@@ -707,10 +707,12 @@ def process_zeekfolder():
 
                     # Read column values from the zeek line
                     try:
-                        if zeekfile_name != 'files.log':
-                            uid = line_values[column_idx['uid']]
-                        elif zeekfile_name == 'files.log':
+                        if zeekfile_name == 'files.log':
                             uid = line_values[column_idx['conn_uids']]
+                        elif zeekfile_name == 'dhcp.log':
+                            uid = line_values[column_idx['uids']]
+                        else:
+                            uid = line_values[column_idx['uid']]
 
                         lines_labeled += 1
 

--- a/zeek-files-labeler.py
+++ b/zeek-files-labeler.py
@@ -110,6 +110,7 @@ def define_columns(headerline, filetype):
     column_idx['detailedlabel'] = False
     column_idx['fingerprint'] = False
     column_idx['id'] = False
+    column_idx['uids'] = False
 
     try:
         if 'csv' in filetype or 'tab' in filetype:
@@ -186,6 +187,8 @@ def define_columns(headerline, filetype):
                     column_idx['label'] = nline.index(field)
                 elif 'fingerprint' in field.lower():
                     column_idx['fingerprint'] = nline.index(field)
+                elif 'uids' in field.lower():
+                    column_idx['uids'] = nline.index(field)
                 elif 'id' in field.lower():
                     column_idx['id'] = nline.index(field)
         elif 'json' in filetype:


### PR DESCRIPTION
# Description

The `dhcp.log` contains a different header. Instead of `uid` contains `uids`. This caused the column not to be parsed properly and, therefore, to generate an empty labelled file.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


- [X] Run locally the zeek-files-labeler.py on a zeek folder
- [X] Manually verified the output is correct


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
